### PR TITLE
いきたいスタンプが押されたときメッセージリンクを取得できるようにした

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -13,12 +13,13 @@ target_reaction = "ikitai"
 @client.event
 async def on_raw_reaction_add(payload):
   channel = client.get_channel(payload.channel_id)
-  message = await channel.fetch_message(payload.message_id)
   reaction = payload.emoji.name
 
   if reaction != target_reaction:
     return
 
-  print(message.system_content)
+  message_link = f'https://discord.com/channels/{config.SERVER_ID}/{channel.id}/{payload.message_id}'
+
+  await channel.send(message_link)
 
 client.run(config.DISCORD_TOKEN)

--- a/bot/settings/config.py
+++ b/bot/settings/config.py
@@ -3,3 +3,4 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DISCORD_TOKEN = os.getenv('DISCORD_TOKEN')
+SERVER_ID=os.getenv('SERVER_ID')


### PR DESCRIPTION
# 概要
いきたいスタンプが押されたメッセージのリンクを取得できるようにした。
一時的にスタンプが押されたチャンネルにメッセージリンクを返すようにしている。

# レビュー希望日
ありません。